### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,7 +9,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: publish
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: docker.pkg.github.com/ryota-sakamoto/argocd-sample/app
           username: ryota-sakamoto


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore